### PR TITLE
Feature compare with current

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
         "command": "groupedHistory.clearSearch",
         "title": "Clear Search",
         "icon": "$(close)"
+      },
+      {
+        "command": "groupedHistory.previewWithCurrent",
+        "title": "Compare with current version",
+        "icon": "$(compare-changes)"
       }
     ],
     "menus": {
@@ -153,6 +158,11 @@
           "command": "groupedHistory.restoreFileToAfter",
           "when": "view == groupedHistory && viewItem == historyEntry",
           "group": "1_modification"
+        },
+        {
+          "command": "groupedHistory.previewWithCurrent",
+          "when": "view == groupedHistory && viewItem == historyEntry",
+          "group": "inline"
         },
         {
           "command": "groupedHistory.clearSearch",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,9 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('groupedHistory.preview', (entry) => 
             restoreManager.previewVersion(entry)
         ),
+        vscode.commands.registerCommand('groupedHistory.previewWithCurrent', (entry) => 
+            restoreManager.previewVersionWithCurrent(entry)
+        ),
         vscode.commands.registerCommand('groupedHistory.restoreGroupToBefore', (group) => 
             restoreManager.restoreGroupToBefore(group)
         ),

--- a/src/historyReader.ts
+++ b/src/historyReader.ts
@@ -32,6 +32,7 @@ export class HistoryReader {
     constructor() {
         // Detect if running in Cursor or VS Code
         const isCursor = vscode.env.appName === 'Cursor';
+        const isWindsurf = vscode.env.appName === 'Windsurf';
         
         // Get appropriate path based on platform and editor
         if (isCursor) {
@@ -40,7 +41,14 @@ export class HistoryReader {
                 : process.platform === 'darwin'
                     ? path.join(process.env.HOME!, 'Library', 'Application Support', 'Cursor', 'User', 'History')
                     : path.join(process.env.HOME!, '.config', 'Cursor', 'User', 'History');
-        } else {
+        } else if (isWindsurf) {
+            // Windsurf history paths
+            this.historyPath = process.platform === 'win32'
+                ? path.join(process.env.APPDATA!, 'Windsurf', 'User', 'History')
+                : process.platform === 'darwin'
+                    ? path.join(process.env.HOME!, 'Library', 'Application Support', 'Windsurf', 'User', 'History')
+                    : path.join(process.env.HOME!, '.windsurf-server', 'data', 'User', 'History');
+        }else {
             // VS Code history paths
             this.historyPath = process.platform === 'win32'
                 ? path.join(process.env.APPDATA!, 'Code', 'User', 'History')
@@ -55,7 +63,7 @@ export class HistoryReader {
             this.initialize(workspaceFolders[0].uri.fsPath);
         }
         else {
-            console.error('No workspace folders found');
+            console.error('No workspace folders found by timeline extension');
         }
     }
 

--- a/src/historyTreeProvider.ts
+++ b/src/historyTreeProvider.ts
@@ -82,6 +82,7 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<GroupedChang
                 description: `${time} • ${path.relative(vscode.workspace.workspaceFolders![0].uri.fsPath, element.filePath)}`,
                 collapsibleState: vscode.TreeItemCollapsibleState.None,
                 contextValue: 'historyEntry',
+                iconPath: new vscode.ThemeIcon('git-compare'),
                 command: {
                     command: 'groupedHistory.preview',
                     title: 'Preview Version',
@@ -186,6 +187,20 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<GroupedChang
         }
 
         return undefined;
+    }
+
+    async getTreeItemContextMenu(element: GroupedChange | HistoryEntry | SearchQueryItem): Promise<vscode.Command[]> {
+        if ('changes' in element) {
+            return [];
+        }
+
+        return [
+            {
+                command: 'groupedHistory.previewWithCurrent',
+                title: 'Compare with current version',
+                arguments: [element]
+            }
+        ];
     }
 
     dispose(): void {


### PR DESCRIPTION
This PR adds a new feature to compare historical versions with the current file version.

Changes:
- Add context menu option "Compare with current version" for history entries
- Add git-compare icon to history entries for better visual feedback
- Implement diff view that shows differences between selected version and current file content

The feature allows users to:
1. Click the file name to see diff between consecutive versions (existing behavior)
2. Click the inline icon "Compare with current version" to see how the selected version differs from the current file